### PR TITLE
Improve how Issue Data is loaded

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,24 +5,22 @@ module.exports = {
       version: "detect",
     },
   },
-  parser: "@typescript-eslint/parser", // Specifies the ESLint parser
+  parser: "@typescript-eslint/parser",
   extends: [
-    "plugin:@typescript-eslint/recommended", // Uses the recommended rules from the @typescript-eslint/eslint-plugin
+    "plugin:@typescript-eslint/recommended",
     "plugin:react/recommended",
-    "plugin:prettier/recommended", // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
+    "plugin:prettier/recommended",
     "plugin:@next/next/recommended",
     "next/core-web-vitals",
     "prettier",
   ],
   plugins: ["@typescript-eslint"],
   parserOptions: {
-    ecmaVersion: 6, // Allows for the parsing of modern ECMAScript features
-    sourceType: "module", // Allows for the use of imports
-    project: ["./tsconfig.json", "./app/tsconfig.json"], // Update the project property to include the path to the tsconfig.json file
+    ecmaVersion: 6,
+    sourceType: "module",
+    project: ["./tsconfig.json", "./app/tsconfig.json"],
   },
   rules: {
-    // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
-    // e.g. "@typescript-eslint/explicit-function-return-type": "off",
     curly: "error",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-explicit-any": "off",
@@ -37,12 +35,9 @@ module.exports = {
     "@typescript-eslint/no-namespace": "off",
     "@typescript-eslint/no-parameter-properties": "off",
     "@typescript-eslint/no-floating-promises": "error",
-    "@typescript-eslint/no-floating-promises": "error",
-    "react/prop-types": "warn",
+    "react/prop-types": "off",
     "@typescript-eslint/ban-ts-comment": "warn",
     "react/display-name": "warn",
-    "react/prop-types": "off",
-    "@typescript-eslint/explicit-module-boundary-types": "off",
     "react/no-unescaped-entities": "off",
     "prefer-const": "error",
     "default-case": "error",
@@ -64,17 +59,11 @@ module.exports = {
         format: ["camelCase"],
         leadingUnderscore: "allow",
       },
-    ],
-    "@typescript-eslint/naming-convention": [
-      "warn",
       {
         selector: "variable",
         format: ["camelCase", "UPPER_CASE"],
         leadingUnderscore: "allow",
       },
-    ],
-    "@typescript-eslint/naming-convention": [
-      "warn",
       {
         selector: ["typeLike", "enumMember"],
         format: ["PascalCase"],

--- a/lib/utils.tsx
+++ b/lib/utils.tsx
@@ -842,29 +842,29 @@ export function getPermalink(props: PermalinkProps) {
 
   switch (type) {
     case PageType.Article:
-      return `./${year}/${month}/${section}/${slug}/`
+      return `${process.env.NEXT_PUBLIC_BASE_URL}/${year}/${month}/${section}/${slug}/`
     case PageType.Section:
-      return `./${year}/${month}/${section}/`
+      return `${process.env.NEXT_PUBLIC_BASE_URL}/${year}/${month}/${section}/`
     case PageType.Issue:
-      return `./${year}/${month}/`
+      return `${process.env.NEXT_PUBLIC_BASE_URL}/${year}/${month}/`
     case PageType.Contributor:
-      return `./contributor/${slug}/`
+      return `${process.env.NEXT_PUBLIC_BASE_URL}/contributor/${slug}/`
     case PageType.Page:
-      return `./${slug}/`
+      return `${process.env.NEXT_PUBLIC_BASE_URL}/${slug}/`
     case PageType.Preview:
-      return `./preview/${slug}/`
+      return `${process.env.NEXT_PUBLIC_BASE_URL}/preview/${slug}/`
     case PageType.SpecialIssue:
-      return `./special/${issueSlug}/`
+      return `${process.env.NEXT_PUBLIC_BASE_URL}/special/${issueSlug}/`
     case PageType.SpecialIssueSection:
-      return `./special/${issueSlug}/${section}/`
+      return `${process.env.NEXT_PUBLIC_BASE_URL}/special/${issueSlug}/${section}/`
     case PageType.SpecialIssueArticle:
-      return `./special/${issueSlug}/${section}/${slug}/`
+      return `${process.env.NEXT_PUBLIC_BASE_URL}/special/${issueSlug}/${section}/${slug}/`
     case PageType.Archive:
-      return `./archive/`
+      return `${process.env.NEXT_PUBLIC_BASE_URL}/archive/`
     case PageType.Search:
-      return `./search/`
+      return `${process.env.NEXT_PUBLIC_BASE_URL}/search/`
     default:
-      return `./`
+      return `${process.env.NEXT_PUBLIC_BASE_URL}/`
   }
 }
 

--- a/lib/utils.tsx
+++ b/lib/utils.tsx
@@ -217,23 +217,6 @@ export async function getGlobalSettings() {
   return data as GlobalSettings
 }
 
-export async function getCurrentIssueBasics() {
-  try {
-    const settings = await getGlobalSettings()
-
-    const issueData = await getIssueBasics({
-      year: settings.current_issue.year,
-      month: settings.current_issue.month,
-    })
-
-    // return the first issue in the array
-    return issueData as Issues
-  } catch (error) {
-    console.error("Error fetching current issue basics data:", error)
-    return null
-  }
-}
-
 // Explore making this get IssueData by ID
 // NOTE: we need to use `readItems` instead of `readItem` because we are querying the `issues` collection
 // instead of a single issue by ID
@@ -488,89 +471,6 @@ export async function getSpecialIssueData(props: SpecialIssueDataProps) {
   } catch (error) {
     // Handle the error here
     console.error("Error fetching getSpecialIssueData data:", error)
-    return null
-  }
-}
-
-interface IssueBasicsProps {
-  year: number
-  month: number
-}
-
-export async function getIssueBasics(props: IssueBasicsProps) {
-  const { year, month } = props
-  const issueBasicsAPI =
-    `${process.env.NEXT_PUBLIC_DIRECTUS_URL}/items/issues` +
-    `?fields[]=id` +
-    `&fields[]=title` +
-    `&fields[]=slug` +
-    `&fields[]=year` +
-    `&fields[]=month` +
-    `&fields[]=status` +
-    `&fields[]=issue_number` +
-    `&fields[]=special_issue` +
-    `&fields[]=section.slug` +
-    `&fields[]=cover_1.caption` +
-    `&fields[]=cover_1.filename_disk` +
-    `&fields[]=cover_1.width` +
-    `&fields[]=cover_1.height` +
-    `&fields[]=cover_1.type` +
-    `&filter[year][_eq]=${year}` +
-    `&filter[month][_eq]=${month}` +
-    `&filter[status][_eq]=published` +
-    `&filter[special_issue][_eq]=false`
-  try {
-    const res = await fetch(issueBasicsAPI)
-    if (!res.ok) {
-      // This will activate the closest `error.js` Error Boundary
-      console.error(`Failed to fetch IssueBasics data: ${res.statusText}`)
-      return null
-    }
-
-    const { data } = await res.json()
-    return data[0] as Issues
-  } catch (error) {
-    console.error(error)
-    return null
-  }
-}
-
-interface SpecialIssueBasicsProps {
-  slug: string
-}
-
-export async function getSpecialIssueBasics(props: SpecialIssueBasicsProps) {
-  const { slug } = props
-  const specialIssueBasicsAPI =
-    `${process.env.NEXT_PUBLIC_DIRECTUS_URL}/items/issues` +
-    `?fields[]=id` +
-    `&fields[]=title` +
-    `&fields[]=slug` +
-    `&fields[]=year` +
-    `&fields[]=month` +
-    `&fields[]=status` +
-    `&fields[]=issue_number` +
-    `&fields[]=special_issue` +
-    `&fields[]=section.slug` +
-    `&fields[]=cover_1.caption` +
-    `&fields[]=cover_1.filename_disk` +
-    `&fields[]=cover_1.width` +
-    `&fields[]=cover_1.height` +
-    `&fields[]=cover_1.type` +
-    `&filter[slug][_eq]=${slug}` +
-    `&filter[status][_in]=published` +
-    `&filter[special_issue][_eq]=true`
-  try {
-    const res = await fetch(specialIssueBasicsAPI)
-    if (!res.ok) {
-      // This will activate the closest `error.js` Error Boundary
-      throw new Error("Failed to fetch getSpecialIssueBasics data")
-    }
-
-    const { data } = await res.json()
-    return data[0] as Issues
-  } catch (error) {
-    console.error("Error fetching getSpecialIssueBasics data:", error)
     return null
   }
 }

--- a/lib/utils.tsx
+++ b/lib/utils.tsx
@@ -841,29 +841,29 @@ export function getPermalink(props: PermalinkProps) {
 
   switch (type) {
     case PageType.Article:
-      return `/${year}/${month}/${section}/${slug}/`
+      return `./${year}/${month}/${section}/${slug}/`
     case PageType.Section:
-      return `/${year}/${month}/${section}/`
+      return `./${year}/${month}/${section}/`
     case PageType.Issue:
-      return `/${year}/${month}/`
+      return `./${year}/${month}/`
     case PageType.Contributor:
-      return `/contributor/${slug}/`
+      return `./contributor/${slug}/`
     case PageType.Page:
-      return `/${slug}/`
+      return `./${slug}/`
     case PageType.Preview:
-      return `/preview/${slug}/`
+      return `./preview/${slug}/`
     case PageType.SpecialIssue:
-      return `/special/${issueSlug}/`
+      return `./special/${issueSlug}/`
     case PageType.SpecialIssueSection:
-      return `/special/${issueSlug}/${section}/`
+      return `./special/${issueSlug}/${section}/`
     case PageType.SpecialIssueArticle:
-      return `/special/${issueSlug}/${section}/${slug}/`
+      return `./special/${issueSlug}/${section}/${slug}/`
     case PageType.Archive:
-      return `/archive/`
+      return `./archive/`
     case PageType.Search:
-      return `/search/`
+      return `./search/`
     default:
-      return `/`
+      return `./`
   }
 }
 

--- a/lib/utils.tsx
+++ b/lib/utils.tsx
@@ -846,7 +846,7 @@ export function getPermalink(props: PermalinkProps) {
   // Localhost: NEXT_PUBLIC_BASE_URL http://localhost:3000
   const baseURL = process.env.NEXT_PUBLIC_BASE_URL
     ? process.env.NEXT_PUBLIC_BASE_URL
-    : `https://${process.env.VERCEL_URL}`
+    : `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
 
   switch (type) {
     case PageType.Article:

--- a/lib/utils.tsx
+++ b/lib/utils.tsx
@@ -841,29 +841,29 @@ export function getPermalink(props: PermalinkProps) {
 
   switch (type) {
     case PageType.Article:
-      return `${process.env.NEXT_PUBLIC_BASE_URL}/${year}/${month}/${section}/${slug}/`
+      return `/${year}/${month}/${section}/${slug}/`
     case PageType.Section:
-      return `${process.env.NEXT_PUBLIC_BASE_URL}/${year}/${month}/${section}/`
+      return `/${year}/${month}/${section}/`
     case PageType.Issue:
-      return `${process.env.NEXT_PUBLIC_BASE_URL}/${year}/${month}/`
+      return `/${year}/${month}/`
     case PageType.Contributor:
-      return `${process.env.NEXT_PUBLIC_BASE_URL}/contributor/${slug}/`
+      return `/contributor/${slug}/`
     case PageType.Page:
-      return `${process.env.NEXT_PUBLIC_BASE_URL}/${slug}/`
+      return `/${slug}/`
     case PageType.Preview:
-      return `${process.env.NEXT_PUBLIC_BASE_URL}/preview/${slug}/`
+      return `/preview/${slug}/`
     case PageType.SpecialIssue:
-      return `${process.env.NEXT_PUBLIC_BASE_URL}/special/${issueSlug}/`
+      return `/special/${issueSlug}/`
     case PageType.SpecialIssueSection:
-      return `${process.env.NEXT_PUBLIC_BASE_URL}/special/${issueSlug}/${section}/`
+      return `/special/${issueSlug}/${section}/`
     case PageType.SpecialIssueArticle:
-      return `${process.env.NEXT_PUBLIC_BASE_URL}/special/${issueSlug}/${section}/${slug}/`
+      return `/special/${issueSlug}/${section}/${slug}/`
     case PageType.Archive:
-      return `${process.env.NEXT_PUBLIC_BASE_URL}/archive/`
+      return `/archive/`
     case PageType.Search:
-      return `${process.env.NEXT_PUBLIC_BASE_URL}/search/`
+      return `/search/`
     default:
-      return `${process.env.NEXT_PUBLIC_BASE_URL}/`
+      return `/`
   }
 }
 

--- a/lib/utils.tsx
+++ b/lib/utils.tsx
@@ -840,31 +840,39 @@ export function getPermalink(props: PermalinkProps) {
   const { year, section, slug, issueSlug, type } = props
   const month = props.month && props.month < 10 ? `0${props.month}` : props.month
 
+  // Production URL: NEXT_PUBLIC_BASE_URL https://brooklynrail.org
+  // Preview URL: NEXT_PUBLIC_BASE_URL https://preview.brooklynrail.org
+  // Branch Previews: VERCEL_URL
+  // Localhost: NEXT_PUBLIC_BASE_URL http://localhost:3000
+  const baseURL = process.env.NEXT_PUBLIC_BASE_URL
+    ? process.env.NEXT_PUBLIC_BASE_URL
+    : `https://${process.env.VERCEL_URL}`
+
   switch (type) {
     case PageType.Article:
-      return `${process.env.NEXT_PUBLIC_BASE_URL}/${year}/${month}/${section}/${slug}/`
+      return `${baseURL}/${year}/${month}/${section}/${slug}/`
     case PageType.Section:
-      return `${process.env.NEXT_PUBLIC_BASE_URL}/${year}/${month}/${section}/`
+      return `${baseURL}/${year}/${month}/${section}/`
     case PageType.Issue:
-      return `${process.env.NEXT_PUBLIC_BASE_URL}/${year}/${month}/`
+      return `${baseURL}/${year}/${month}/`
     case PageType.Contributor:
-      return `${process.env.NEXT_PUBLIC_BASE_URL}/contributor/${slug}/`
+      return `${baseURL}/contributor/${slug}/`
     case PageType.Page:
-      return `${process.env.NEXT_PUBLIC_BASE_URL}/${slug}/`
+      return `${baseURL}/${slug}/`
     case PageType.Preview:
-      return `${process.env.NEXT_PUBLIC_BASE_URL}/preview/${slug}/`
+      return `${baseURL}/preview/${slug}/`
     case PageType.SpecialIssue:
-      return `${process.env.NEXT_PUBLIC_BASE_URL}/special/${issueSlug}/`
+      return `${baseURL}/special/${issueSlug}/`
     case PageType.SpecialIssueSection:
-      return `${process.env.NEXT_PUBLIC_BASE_URL}/special/${issueSlug}/${section}/`
+      return `${baseURL}/special/${issueSlug}/${section}/`
     case PageType.SpecialIssueArticle:
-      return `${process.env.NEXT_PUBLIC_BASE_URL}/special/${issueSlug}/${section}/${slug}/`
+      return `${baseURL}/special/${issueSlug}/${section}/${slug}/`
     case PageType.Archive:
-      return `${process.env.NEXT_PUBLIC_BASE_URL}/archive/`
+      return `${baseURL}/archive/`
     case PageType.Search:
-      return `${process.env.NEXT_PUBLIC_BASE_URL}/search/`
+      return `${baseURL}/search/`
     default:
-      return `${process.env.NEXT_PUBLIC_BASE_URL}/`
+      return `${baseURL}/`
   }
 }
 

--- a/src/app/[...slug]/page.tsx
+++ b/src/app/[...slug]/page.tsx
@@ -9,7 +9,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 60 seconds.
-export const revalidate = process.env.VERCEL_ENV === "production" ? 600 : 0
+export const revalidate = process.env.NEXT_PUBLIC_VERCEL_ENV === "production" ? 600 : 0
 export interface PageProps {
   pageData: Pages
   thisIssueData: Issues

--- a/src/app/[...slug]/page.tsx
+++ b/src/app/[...slug]/page.tsx
@@ -12,7 +12,7 @@ export const dynamicParams = true
 export const revalidate = 60
 export interface PageProps {
   pageData: Pages
-  issueBasics: Issues
+  thisIssueData: Issues
   permalink: string
   errorCode?: number
   errorMessage?: string
@@ -20,13 +20,13 @@ export interface PageProps {
 
 interface PageParams {
   slug: string
-  issueBasics: Issues
+  thisIssueData: Issues
 }
 
 export default async function SinglePage({ params }: { params: PageParams }) {
   const data = await getData({ params })
 
-  if (!data.issueBasics || !data.pageData || !data.permalink) {
+  if (!data.thisIssueData || !data.pageData || !data.permalink) {
     return notFound()
   }
 
@@ -45,8 +45,8 @@ async function getData({ params }: { params: PageParams }) {
     return notFound()
   }
 
-  const issueBasics = await getCurrentIssueData()
-  if (!issueBasics) {
+  const thisIssueData = await getCurrentIssueData()
+  if (!thisIssueData) {
     return notFound()
   }
 
@@ -57,7 +57,7 @@ async function getData({ params }: { params: PageParams }) {
 
   return {
     pageData,
-    issueBasics,
+    thisIssueData,
     permalink,
   }
 }

--- a/src/app/[...slug]/page.tsx
+++ b/src/app/[...slug]/page.tsx
@@ -9,7 +9,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 60 seconds.
-export const revalidate = 600
+export const revalidate = process.env.VERCEL_ENV === "production" ? 600 : 0
 export interface PageProps {
   pageData: Pages
   thisIssueData: Issues

--- a/src/app/[year]/[month]/[section]/[slug]/page.tsx
+++ b/src/app/[year]/[month]/[section]/[slug]/page.tsx
@@ -18,7 +18,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every day.
-export const revalidate = 3600
+export const revalidate = process.env.NODE_ENV === "production" ? 3600 : 0
 
 export async function generateMetadata({ params }: any): Promise<Metadata> {
   const data = await getData({ params })

--- a/src/app/[year]/[month]/[section]/[slug]/page.tsx
+++ b/src/app/[year]/[month]/[section]/[slug]/page.tsx
@@ -128,26 +128,26 @@ export default async function ArticlePageController({ params }: { params: Articl
   return <Article {...data.props} />
 }
 
-export async function generateStaticParams() {
-  const articlePages = await getArticlePages()
+// export async function generateStaticParams() {
+//   const articlePages = await getArticlePages()
 
-  if (!articlePages) {
-    return notFound()
-  }
+//   if (!articlePages) {
+//     return notFound()
+//   }
 
-  return articlePages.map((article: Articles) => {
-    // NOTE: This is returning articles with no issues.
-    // These are the articles that are part of the "Special Issues"
-    // This might be a BUG, or might be how the REST API is set up.
-    if (!article.issue) {
-      return
-    }
-    const month = article.issue.month
-    return {
-      year: article.issue.year.toString(),
-      month: month < 10 ? `0${month.toString()}` : month.toString(),
-      section: article.section.slug,
-      slug: article.slug,
-    }
-  })
-}
+//   return articlePages.map((article: Articles) => {
+//     // NOTE: This is returning articles with no issues.
+//     // These are the articles that are part of the "Special Issues"
+//     // This might be a BUG, or might be how the REST API is set up.
+//     if (!article.issue) {
+//       return
+//     }
+//     const month = article.issue.month
+//     return {
+//       year: article.issue.year.toString(),
+//       month: month < 10 ? `0${month.toString()}` : month.toString(),
+//       section: article.section.slug,
+//       slug: article.slug,
+//     }
+//   })
+// }

--- a/src/app/[year]/[month]/[section]/[slug]/page.tsx
+++ b/src/app/[year]/[month]/[section]/[slug]/page.tsx
@@ -18,7 +18,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every day.
-export const revalidate = process.env.VERCEL_ENV === "production" ? 3600 : 0
+export const revalidate = process.env.NEXT_PUBLIC_VERCEL_ENV === "production" ? 3600 : 0
 
 export async function generateMetadata({ params }: any): Promise<Metadata> {
   const data = await getData({ params })

--- a/src/app/[year]/[month]/[section]/[slug]/page.tsx
+++ b/src/app/[year]/[month]/[section]/[slug]/page.tsx
@@ -76,7 +76,7 @@ async function getData({ params }: { params: ArticleParams }) {
   const slug: string = params.slug.toString()
   const section: string = params.section.toString()
 
-  const thisIssueData = await getIssueData({ year, month }) // A limited set of data for the issue
+  const thisIssueData = await getIssueData({ year, month })
   if (!thisIssueData) {
     return notFound()
   }

--- a/src/app/[year]/[month]/[section]/[slug]/page.tsx
+++ b/src/app/[year]/[month]/[section]/[slug]/page.tsx
@@ -1,5 +1,12 @@
 import { stripHtml } from "string-strip-html"
-import { PageType, getArticle, getIssueData, getOGImage, getPermalink } from "../../../../../../lib/utils"
+import {
+  PageType,
+  getArticle,
+  getArticlePages,
+  getIssueData,
+  getOGImage,
+  getPermalink,
+} from "../../../../../../lib/utils"
 import { Articles, Issues, Sections } from "../../../../../../lib/types"
 import { Metadata } from "next"
 import Article from "@/app/components/article"
@@ -119,4 +126,28 @@ export default async function ArticlePageController({ params }: { params: Articl
   }
 
   return <Article {...data.props} />
+}
+
+export async function generateStaticParams() {
+  const articlePages = await getArticlePages()
+
+  if (!articlePages) {
+    return notFound()
+  }
+
+  return articlePages.map((article: Articles) => {
+    // NOTE: This is returning articles with no issues.
+    // These are the articles that are part of the "Special Issues"
+    // This might be a BUG, or might be how the REST API is set up.
+    if (!article.issue) {
+      return
+    }
+    const month = article.issue.month
+    return {
+      year: article.issue.year.toString(),
+      month: month < 10 ? `0${month.toString()}` : month.toString(),
+      section: article.section.slug,
+      slug: article.slug,
+    }
+  })
 }

--- a/src/app/[year]/[month]/[section]/[slug]/page.tsx
+++ b/src/app/[year]/[month]/[section]/[slug]/page.tsx
@@ -18,7 +18,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every day.
-export const revalidate = process.env.NODE_ENV === "production" ? 3600 : 0
+export const revalidate = process.env.VERCEL_ENV === "production" ? 3600 : 0
 
 export async function generateMetadata({ params }: any): Promise<Metadata> {
   const data = await getData({ params })

--- a/src/app/[year]/[month]/[section]/[slug]/page.tsx
+++ b/src/app/[year]/[month]/[section]/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import { stripHtml } from "string-strip-html"
-import { PageType, getArticle, getIssueBasics, getOGImage, getPermalink } from "../../../../../../lib/utils"
+import { PageType, getArticle, getIssueData, getOGImage, getPermalink } from "../../../../../../lib/utils"
 import { Articles, Issues, Sections } from "../../../../../../lib/types"
 import { Metadata } from "next"
 import Article from "@/app/components/article"
@@ -56,7 +56,7 @@ export async function generateMetadata({ params }: any): Promise<Metadata> {
 }
 export interface ArticleProps {
   articleData: Articles
-  issueBasics: Issues
+  thisIssueData: Issues
   currentSection?: Sections
   permalink: string
   errorCode?: number
@@ -76,8 +76,8 @@ async function getData({ params }: { params: ArticleParams }) {
   const slug: string = params.slug.toString()
   const section: string = params.section.toString()
 
-  const issueBasics = await getIssueBasics({ year, month }) // A limited set of data for the issue
-  if (!issueBasics) {
+  const thisIssueData = await getIssueData({ year, month }) // A limited set of data for the issue
+  if (!thisIssueData) {
     return notFound()
   }
 
@@ -94,8 +94,8 @@ async function getData({ params }: { params: ArticleParams }) {
   }
 
   const permalink = getPermalink({
-    year: issueBasics.year,
-    month: issueBasics.month,
+    year: thisIssueData.year,
+    month: thisIssueData.month,
     section: currentSection.slug,
     slug: articleData.slug,
     type: PageType.Article,
@@ -104,7 +104,7 @@ async function getData({ params }: { params: ArticleParams }) {
   return {
     props: {
       articleData,
-      issueBasics,
+      thisIssueData,
       currentSection,
       permalink,
     },

--- a/src/app/[year]/[month]/[section]/page.tsx
+++ b/src/app/[year]/[month]/[section]/page.tsx
@@ -28,7 +28,7 @@ export async function generateMetadata({ params }: { params: SectionParams }): P
   }
 
   const { name } = data.props.currentSection
-  const { title, cover_1, issue_number } = data.props.issueData
+  const { title, cover_1, issue_number } = data.props.thisIssueData
   const ogtitle = `${name} – ${stripHtml(title).result}`
   const ogdescription = `The ${name} section of issue #${issue_number} of The Brooklyn Rail`
   const ogimageprops = { ogimage: cover_1, title }
@@ -71,23 +71,21 @@ async function getData({ params }: { params: SectionParams }) {
   const month = Number(params.month)
   const section = params.section.toString()
 
-  const issueData = await getIssueData({
+  const thisIssueData = await getIssueData({
     year: year,
     month: month,
   })
 
-  if (!issueData) {
+  if (!thisIssueData) {
     return notFound()
   }
 
-  // Get the current list of Sections used in this Issue (draft or published)
-  const currentSections = await getSectionsByIssueId(issueData.id, issueData.status)
+  // make an array of all the sections used in thisIssueData.articles and remove any duplicates
+  const issueSections = thisIssueData.articles
+    .map((article) => article.section)
+    .filter((section, index, self) => self.findIndex((s) => s.id === section.id) === index)
 
-  if (!currentSections) {
-    return { props: { errorCode: 404, errorMessage: "No currentSections found" } }
-  }
-
-  const currentSection = currentSections.find((s: Sections) => s.slug === section)
+  const currentSection = issueSections.find((s: Sections) => s.slug === section)
 
   // If `section` does not exist, set errorCode to a string
   if (!currentSection) {
@@ -95,16 +93,16 @@ async function getData({ params }: { params: SectionParams }) {
   }
 
   const permalink = getPermalink({
-    year: issueData.year,
-    month: issueData.month,
+    year: thisIssueData.year,
+    month: thisIssueData.month,
     section: currentSection.slug,
     type: PageType.Section,
   })
 
   return {
     props: {
-      issueData,
-      sections: currentSections,
+      thisIssueData,
+      issueSections,
       currentSection,
       permalink,
     },

--- a/src/app/[year]/[month]/[section]/page.tsx
+++ b/src/app/[year]/[month]/[section]/page.tsx
@@ -12,7 +12,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 60 seconds.
-export const revalidate = process.env.VERCEL_ENV === "production" ? 600 : 0
+export const revalidate = process.env.NEXT_PUBLIC_VERCEL_ENV === "production" ? 600 : 0
 
 // Set the Viewport to show the full page of the Rail on mobile devices
 export const viewport: Viewport = {

--- a/src/app/[year]/[month]/[section]/page.tsx
+++ b/src/app/[year]/[month]/[section]/page.tsx
@@ -12,7 +12,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 60 seconds.
-export const revalidate = process.env.NODE_ENV === "production" ? 600 : 0
+export const revalidate = process.env.VERCEL_ENV === "production" ? 600 : 0
 
 // Set the Viewport to show the full page of the Rail on mobile devices
 export const viewport: Viewport = {

--- a/src/app/[year]/[month]/[section]/page.tsx
+++ b/src/app/[year]/[month]/[section]/page.tsx
@@ -1,5 +1,5 @@
 import { PageLayout } from "@/app/page"
-import { PageType, getIssueData, getOGImage, getPermalink, getSectionsByIssueId } from "../../../../../lib/utils"
+import { PageType, getIssueData, getOGImage, getPermalink } from "../../../../../lib/utils"
 import { stripHtml } from "string-strip-html"
 import { Sections } from "../../../../../lib/types"
 import IssuePage from "@/app/components/issuePage"

--- a/src/app/[year]/[month]/[section]/page.tsx
+++ b/src/app/[year]/[month]/[section]/page.tsx
@@ -12,7 +12,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 60 seconds.
-export const revalidate = 600
+export const revalidate = process.env.NODE_ENV === "production" ? 600 : 0
 
 // Set the Viewport to show the full page of the Rail on mobile devices
 export const viewport: Viewport = {

--- a/src/app/[year]/[month]/page.tsx
+++ b/src/app/[year]/[month]/page.tsx
@@ -11,7 +11,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 60 seconds.
-export const revalidate = process.env.VERCEL_ENV === "production" ? 600 : 0
+export const revalidate = process.env.NEXT_PUBLIC_VERCEL_ENV === "production" ? 600 : 0
 
 // Set the Viewport to show the full page of the Rail on mobile devices
 export const viewport: Viewport = {

--- a/src/app/[year]/[month]/page.tsx
+++ b/src/app/[year]/[month]/page.tsx
@@ -11,7 +11,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 60 seconds.
-export const revalidate = process.env.NODE_ENV === "production" ? 600 : 0
+export const revalidate = process.env.VERCEL_ENV === "production" ? 600 : 0
 
 // Set the Viewport to show the full page of the Rail on mobile devices
 export const viewport: Viewport = {

--- a/src/app/[year]/[month]/page.tsx
+++ b/src/app/[year]/[month]/page.tsx
@@ -11,7 +11,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 60 seconds.
-export const revalidate = 600
+export const revalidate = process.env.NODE_ENV === "production" ? 600 : 0
 
 // Set the Viewport to show the full page of the Rail on mobile devices
 export const viewport: Viewport = {

--- a/src/app/[year]/[month]/page.tsx
+++ b/src/app/[year]/[month]/page.tsx
@@ -1,13 +1,6 @@
 import IssuePage from "@/app/components/issuePage"
 import { PageLayout } from "@/app/page"
-import {
-  PageType,
-  getIssueData,
-  getIssues,
-  getOGImage,
-  getPermalink,
-  getSectionsByIssueId,
-} from "../../../../lib/utils"
+import { PageType, getIssueData, getOGImage, getPermalink } from "../../../../lib/utils"
 import { stripHtml } from "string-strip-html"
 import { Metadata, Viewport } from "next"
 import { notFound } from "next/navigation"
@@ -29,7 +22,7 @@ export const viewport: Viewport = {
 export async function generateMetadata({ params }: { params: IssueParams }): Promise<Metadata> {
   const data = await getData({ params })
 
-  const { title, cover_1, issue_number } = data.issueData
+  const { title, cover_1, issue_number } = data.thisIssueData
   const ogtitle = `${stripHtml(title).result}`
   const ogdescription = `Issue #${issue_number} of The Brooklyn Rail`
   const ogimageprops = { ogimage: cover_1, title }
@@ -66,44 +59,43 @@ async function getData({ params }: { params: IssueParams }) {
   const year = Number(params.year)
   const month = Number(params.month)
 
-  const issueData = await getIssueData({
+  const thisIssueData = await getIssueData({
     year: year,
     month: month,
   })
 
-  if (!issueData) {
+  if (!thisIssueData) {
     return notFound()
   }
 
-  // Get the current list of Sections used in this Issue (draft or published)
-  const sections = await getSectionsByIssueId(issueData.id, issueData.status)
-  if (!sections) {
-    return notFound()
-  }
+  // make an array of all the sections used in thisIssueData.articles and remove any duplicates
+  const issueSections = thisIssueData.articles
+    .map((article) => article.section)
+    .filter((section, index, self) => self.findIndex((s) => s.id === section.id) === index)
 
   const permalink = getPermalink({
-    year: issueData.year,
-    month: issueData.month,
+    year: thisIssueData.year,
+    month: thisIssueData.month,
     type: PageType.Issue,
   })
 
   return {
-    issueData,
-    sections,
+    thisIssueData,
+    issueSections,
     permalink,
   }
 }
 
-export async function generateStaticParams() {
-  const allIssues = await getIssues()
-  if (!allIssues) {
-    return notFound()
-  }
-  return allIssues.map((issue) => {
-    const month = issue.month < 10 ? String(`0${issue.month}`) : String(issue.month)
-    return {
-      year: String(issue.year),
-      month: month,
-    }
-  })
-}
+// export async function generateStaticParams() {
+//   const allIssues = await getIssues()
+//   if (!allIssues) {
+//     return notFound()
+//   }
+//   return allIssues.map((issue) => {
+//     const month = issue.month < 10 ? String(`0${issue.month}`) : String(issue.month)
+//     return {
+//       year: String(issue.year),
+//       month: month,
+//     }
+//   })
+// }

--- a/src/app/[year]/[month]/table_of_contents/page.tsx
+++ b/src/app/[year]/[month]/table_of_contents/page.tsx
@@ -11,7 +11,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 5 mins.
-export const revalidate = 300
+export const revalidate = process.env.VERCEL_ENV === "production" ? 600 : 0
 
 // Set the Viewport to show the full page of the Rail on mobile devices
 export const viewport: Viewport = {

--- a/src/app/[year]/[month]/table_of_contents/page.tsx
+++ b/src/app/[year]/[month]/table_of_contents/page.tsx
@@ -11,7 +11,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 5 mins.
-export const revalidate = process.env.VERCEL_ENV === "production" ? 600 : 0
+export const revalidate = process.env.NEXT_PUBLIC_VERCEL_ENV === "production" ? 600 : 0
 
 // Set the Viewport to show the full page of the Rail on mobile devices
 export const viewport: Viewport = {

--- a/src/app/[year]/[month]/table_of_contents/page.tsx
+++ b/src/app/[year]/[month]/table_of_contents/page.tsx
@@ -22,7 +22,7 @@ export const viewport: Viewport = {
 export async function generateMetadata({ params }: { params: IssueParams }): Promise<Metadata> {
   const data = await getData({ params })
 
-  const { title, cover_1, issue_number } = data.issueData
+  const { title, cover_1, issue_number } = data.thisIssueData
   const ogtitle = `${stripHtml(title).result}`
   const ogdescription = `Issue #${issue_number} of The Brooklyn Rail`
   const ogimageprops = { ogimage: cover_1, title }
@@ -59,31 +59,29 @@ async function getData({ params }: { params: IssueParams }) {
   const year = Number(params.year)
   const month = Number(params.month)
 
-  const issueData = await getIssueData({
+  const thisIssueData = await getIssueData({
     year: year,
     month: month,
   })
 
-  if (!issueData) {
+  if (!thisIssueData) {
     return notFound()
   }
 
-  // Get the current list of Sections used in this Issue (draft or published)
-  const sections = await getSectionsByIssueId(issueData.id, issueData.status)
-
-  if (!sections) {
-    return notFound()
-  }
+  // make an array of all the sections used in thisIssueData.articles and remove any duplicates
+  const issueSections = thisIssueData.articles
+    .map((article) => article.section)
+    .filter((section, index, self) => self.findIndex((s) => s.id === section.id) === index)
 
   const permalink = getPermalink({
-    year: issueData.year,
-    month: issueData.month,
+    year: thisIssueData.year,
+    month: thisIssueData.month,
     type: PageType.Issue,
   })
 
   return {
-    issueData,
-    sections,
+    thisIssueData,
+    issueSections,
     permalink,
   }
 }

--- a/src/app/[year]/[month]/table_of_contents/page.tsx
+++ b/src/app/[year]/[month]/table_of_contents/page.tsx
@@ -1,6 +1,6 @@
 import IssuePage from "@/app/components/issuePage"
 import { PageLayout } from "@/app/page"
-import { PageType, getIssueData, getOGImage, getPermalink, getSectionsByIssueId } from "../../../../../lib/utils"
+import { PageType, getIssueData, getOGImage, getPermalink } from "../../../../../lib/utils"
 import { stripHtml } from "string-strip-html"
 import { Metadata, Viewport } from "next"
 import { notFound } from "next/navigation"

--- a/src/app/archive/page.tsx
+++ b/src/app/archive/page.tsx
@@ -10,7 +10,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 60 seconds.
-export const revalidate = 600
+export const revalidate = process.env.VERCEL_ENV === "production" ? 600 : 0
 
 // Set the Viewport to show the full page of the Rail on mobile devices
 export const viewport: Viewport = {

--- a/src/app/archive/page.tsx
+++ b/src/app/archive/page.tsx
@@ -25,14 +25,6 @@ export enum PageLayout {
   SpecialSection = "special-section",
   Contributor = "contributor",
 }
-export interface IssuePageProps {
-  issueData: Issues
-  currentSection?: Sections
-  permalink: string
-  errorCode?: number
-  errorMessage?: string
-  layout: PageLayout
-}
 
 export default async function Homepage() {
   const data = await getData()

--- a/src/app/archive/page.tsx
+++ b/src/app/archive/page.tsx
@@ -10,7 +10,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 60 seconds.
-export const revalidate = process.env.VERCEL_ENV === "production" ? 600 : 0
+export const revalidate = process.env.NEXT_PUBLIC_VERCEL_ENV === "production" ? 600 : 0
 
 // Set the Viewport to show the full page of the Rail on mobile devices
 export const viewport: Viewport = {

--- a/src/app/components/article/articleHead.tsx
+++ b/src/app/components/article/articleHead.tsx
@@ -42,7 +42,7 @@ const FeaturedImage = (props: FeaturedImageProps) => {
 
 interface ArticleHeadProps {
   permalink: string
-  issueBasics?: Issues
+  thisIssueData?: Issues
   currentSection?: Sections
   articleData: Articles
 }
@@ -90,10 +90,10 @@ const Authors = (props: AuthorsProps) => {
 }
 
 const ArticleHead = (props: ArticleHeadProps) => {
-  const { permalink, issueBasics, currentSection, articleData } = props
+  const { permalink, thisIssueData, currentSection, articleData } = props
   const { kicker, title, deck, featured_image, header_type, contributors, hide_bylines, byline_override } = articleData
 
-  const kickerProps = { kicker, issueBasics, currentSection }
+  const kickerProps = { kicker, thisIssueData, currentSection }
 
   const articleMeta = (
     <div className="article-meta">
@@ -112,7 +112,7 @@ const ArticleHead = (props: ArticleHeadProps) => {
         </cite>
       )}
 
-      {issueBasics && <div className="date">{issueBasics.title}</div>}
+      {thisIssueData && <div className="date">{thisIssueData.title}</div>}
 
       <div className="share-tools">
         <Link

--- a/src/app/components/article/index.tsx
+++ b/src/app/components/article/index.tsx
@@ -14,12 +14,12 @@ import parse from "html-react-parser"
 import Script from "next/script"
 import NextPrev from "./nextPrev"
 import Ad970 from "../ads/ad970"
-import { get } from "http"
 
 const Article = (props: ArticleProps) => {
-  const { articleData, issueBasics } = props
+  const { articleData, thisIssueData } = props
   const { contributors, endnote, section } = articleData
   const [currentAds, setCurrentAds] = useState<Ads[] | undefined>(undefined)
+
   useEffect(() => {
     const fetchData = async () => {
       if (!currentAds) {
@@ -35,11 +35,11 @@ const Article = (props: ArticleProps) => {
     fetchData().catch((error) => console.error("Failed to fetch Ad data on Article page:", error))
   }, [currentAds])
 
-  const issueClass = `issue-${issueBasics.slug.toLowerCase()}`
+  const issueClass = `issue-${thisIssueData.slug.toLowerCase()}`
 
   const issuePermalink = getPermalink({
-    year: issueBasics.year,
-    month: issueBasics.month,
+    year: thisIssueData.year,
+    month: thisIssueData.month,
     type: PageType.Issue,
   })
 
@@ -50,13 +50,13 @@ const Article = (props: ArticleProps) => {
           <div className="grid-container">
             <div className="grid-row grid-gap-3">
               <div className="grid-col-12 tablet-lg:grid-col-4 desktop-lg:grid-col-3">
-                <IssueRail currentIssueBasics={issueBasics} />
+                <IssueRail thisIssueData={thisIssueData} />
               </div>
 
               <div className="grid-col-12 tablet-lg:grid-col-8 desktop-lg:grid-col-9">
                 <header id="article_header">
                   <Link className="mobile_nav_btn" href={issuePermalink}>
-                    <i className="fas fa-angle-double-left"></i> <span>{props.issueBasics.title}</span> Issue
+                    <i className="fas fa-angle-double-left"></i> <span>{props.thisIssueData.title}</span> Issue
                   </Link>
 
                   <nav>

--- a/src/app/components/article/kicker.tsx
+++ b/src/app/components/article/kicker.tsx
@@ -4,15 +4,15 @@ import { getPermalink, PageType } from "../../../../lib/utils"
 
 interface KickerProps {
   kicker?: string | null
-  issueBasics?: Issues
+  thisIssueData?: Issues
   currentSection?: Sections
 }
 const Kicker = (props: KickerProps) => {
-  const { kicker, issueBasics, currentSection } = props
-  if (!issueBasics || !currentSection) {
+  const { kicker, thisIssueData, currentSection } = props
+  if (!thisIssueData || !currentSection) {
     return <></>
   }
-  const { year, month } = issueBasics
+  const { year, month } = thisIssueData
 
   const sectionPermalink = getPermalink({
     year: year,

--- a/src/app/components/article/nextPrev.tsx
+++ b/src/app/components/article/nextPrev.tsx
@@ -1,50 +1,21 @@
 import parse from "html-react-parser"
-import { Articles, Issues } from "../../../../lib/types"
+import { Articles } from "../../../../lib/types"
 import { ArticleProps } from "@/app/[year]/[month]/[section]/[slug]/page"
-import { PageType, getIssueData, getPermalink, getSpecialIssueData } from "../../../../lib/utils"
+import { PageType, getPermalink } from "../../../../lib/utils"
 import Link from "next/link"
-import { useEffect, useState } from "react"
 
 export const NextPrev = (props: ArticleProps) => {
-  const { issueBasics, currentSection, articleData } = props
+  const { thisIssueData, currentSection, articleData } = props
   const { slug } = articleData
-  const issueName = issueBasics.title
-
-  const [issueData, setIssueData] = useState<Issues | null>(null)
-
-  useEffect(() => {
-    const fetchData = async () => {
-      // TODO: Refactor this to use a single function to fetch issue data from APIs
-      let issueDataPromise
-      if (!issueData) {
-        if (issueBasics.special_issue) {
-          issueDataPromise = !issueData ? getSpecialIssueData({ slug: issueBasics.slug }) : Promise.resolve(issueData)
-        } else {
-          issueDataPromise = !issueData
-            ? getIssueData({ year: issueBasics.year, month: issueBasics.month })
-            : Promise.resolve(issueData)
-        }
-        // Fetch all the data in parallel
-        const [fetchedIssueData] = await Promise.all([issueDataPromise])
-        // Update the state with the fetched data as it becomes available
-        setIssueData(fetchedIssueData)
-      }
-    }
-    // Call the fetchData function and handle any errors
-    fetchData().catch((error) => console.error("Failed to fetch data on Article page:", error))
-  }, [issueBasics, issueData, setIssueData])
-
-  if (!issueData || !currentSection) {
-    return <LoadingNextPrev />
-  }
+  const issueName = thisIssueData.title
 
   const issuePermalink = getPermalink({
-    year: issueData.year,
-    month: issueData.month,
+    year: thisIssueData.year,
+    month: thisIssueData.month,
     type: PageType.Issue,
   })
 
-  const issueArticles = issueData.articles
+  const issueArticles = thisIssueData.articles
 
   const articlesListCount = issueArticles.length
   // get the currentArticleIndex
@@ -65,8 +36,8 @@ export const NextPrev = (props: ArticleProps) => {
     const prev: Articles = issueArticles[currentArticleIndex - 1]
 
     const prevPermalink = getPermalink({
-      year: issueBasics.year,
-      month: issueBasics.month,
+      year: thisIssueData.year,
+      month: thisIssueData.month,
       section: prev.section.slug,
       slug: prev.slug,
       type: PageType.Article,
@@ -100,8 +71,8 @@ export const NextPrev = (props: ArticleProps) => {
       )
     }
     const nextPermalink = getPermalink({
-      year: issueBasics.year,
-      month: issueBasics.month,
+      year: thisIssueData.year,
+      month: thisIssueData.month,
       section: next.section.slug,
       slug: next.slug,
       type: PageType.Article,
@@ -133,32 +104,3 @@ export const NextPrev = (props: ArticleProps) => {
 }
 
 export default NextPrev
-
-const LoadingNextPrev = () => {
-  return (
-    <nav className="next-prev loading">
-      <div className="prev">
-        <div>
-          <span className="nav"></span>
-          <h4>
-            <span style={{ width: `60px` }}></span>
-          </h4>
-          <h3>
-            <span style={{ width: `255px` }}></span>
-          </h3>
-        </div>
-      </div>
-      <div className="next">
-        <div>
-          <span className="nav"></span>
-          <h4>
-            <span style={{ width: `60px` }}></span>
-          </h4>
-          <h3>
-            <span style={{ width: `255px` }}></span>
-          </h3>
-        </div>
-      </div>
-    </nav>
-  )
-}

--- a/src/app/components/issuePage/currentSections.tsx
+++ b/src/app/components/issuePage/currentSections.tsx
@@ -3,13 +3,13 @@ import { Issues, Sections } from "../../../../lib/types"
 import { PageType, getPermalink } from "../../../../lib/utils"
 
 interface CurrentSectionsProps {
-  sections: Array<Sections>
-  issueData: Issues
+  issueSections: Array<Sections>
+  thisIssueData: Issues
 }
 
 const CurrentSections = (props: CurrentSectionsProps) => {
-  const { sections, issueData } = props
-  const { year, month, slug, special_issue } = issueData
+  const { issueSections, thisIssueData } = props
+  const { year, month, slug, special_issue } = thisIssueData
   const sectionsToRemove = ["publishersmessage", "editorsmessage"]
 
   const issuePermalink = special_issue
@@ -23,7 +23,7 @@ const CurrentSections = (props: CurrentSectionsProps) => {
         type: PageType.Issue,
       })
 
-  const sectionsList = sections.map((section: Sections, i: number) => {
+  const sectionsList = issueSections.map((section: Sections, i: number) => {
     const sectionPermalink = special_issue
       ? getPermalink({
           issueSlug: slug,

--- a/src/app/components/issuePage/featuredArticles.tsx
+++ b/src/app/components/issuePage/featuredArticles.tsx
@@ -29,7 +29,6 @@ const FeaturedArticles = (props: PromoProps) => {
           slug: article.slug,
           type: PageType.Article,
         })
-        console.log("featuref article permalink: ===========", permalink)
         const sectionPermalink = getPermalink({
           year: year,
           month: month,

--- a/src/app/components/issuePage/featuredArticles.tsx
+++ b/src/app/components/issuePage/featuredArticles.tsx
@@ -29,6 +29,7 @@ const FeaturedArticles = (props: PromoProps) => {
           slug: article.slug,
           type: PageType.Article,
         })
+        console.log("featuref article permalink: ===========", permalink)
         const sectionPermalink = getPermalink({
           year: year,
           month: month,

--- a/src/app/components/issuePage/index.tsx
+++ b/src/app/components/issuePage/index.tsx
@@ -28,7 +28,7 @@ export interface PromoProps {
 }
 
 const IssuePage = (props: IssuePageProps) => {
-  const { issueData, currentSection, sections, previewURL } = props
+  const { thisIssueData, currentSection, issueSections, previewURL } = props
   const [currentAds, setCurrentAds] = useState<Ads[] | undefined>(undefined)
 
   useEffect(() => {
@@ -41,24 +41,23 @@ const IssuePage = (props: IssuePageProps) => {
         setCurrentAds(fetchedAds)
       }
     }
-
     // Call the fetchData function and handle any errors
     fetchData().catch((error) => console.error("Failed to fetch data on Issue Page:", error))
-  }, [issueData, currentAds])
+  }, [currentAds])
 
-  const { slug } = issueData
+  const { slug } = thisIssueData
   const issueClass = `issue-${slug.toLowerCase()}`
 
   let layout
   switch (props.layout) {
     case PageLayout.Section:
-      layout = <SectionLayout issueData={issueData} currentSection={currentSection} />
+      layout = <SectionLayout thisIssueData={thisIssueData} currentSection={currentSection} />
       break
     case PageLayout.SpecialSection:
-      layout = <SpecialSection issueData={issueData} currentSection={currentSection} />
+      layout = <SpecialSection thisIssueData={thisIssueData} currentSection={currentSection} />
       break
     case PageLayout.SpecialIssue:
-      layout = <SpecialIssue issueData={issueData} />
+      layout = <SpecialIssue thisIssueData={thisIssueData} />
       break
     case PageLayout.TableOfContents:
       layout = <TableOfContentsPage {...props} />
@@ -79,9 +78,9 @@ const IssuePage = (props: IssuePageProps) => {
                 <div className="grid-row">
                   <div className="grid-col-12">
                     <Header
-                      special_issue={issueData.special_issue}
-                      issue_number={issueData.issue_number}
-                      title={issueData.title}
+                      special_issue={thisIssueData.special_issue}
+                      issue_number={thisIssueData.issue_number}
+                      title={thisIssueData.title}
                     />
                   </div>
                 </div>
@@ -97,10 +96,10 @@ const IssuePage = (props: IssuePageProps) => {
                     <div id="issuecolumn">
                       <div className="youarehereissue">
                         <IssueSelect currentIssueSlug={slug} />
-                        <CoverImage issueBasics={issueData} />
+                        <CoverImage thisIssueData={thisIssueData} />
                       </div>
 
-                      <CurrentSections sections={sections} issueData={issueData} />
+                      <CurrentSections issueSections={issueSections} thisIssueData={thisIssueData} />
 
                       {/* <Link className="search_btn" href="/search" title="Search All Issues">
                         <span>Search</span> <i className="fas fa-search"></i>

--- a/src/app/components/issuePage/index.tsx
+++ b/src/app/components/issuePage/index.tsx
@@ -34,6 +34,13 @@ const IssuePage = (props: IssuePageProps) => {
   const env = process.env.NODE_ENV
   console.log("env", env)
   console.log("NEXT_PUBLIC_BASE_URL: ", process.env.NEXT_PUBLIC_BASE_URL)
+  console.log("VERCEL_URL: ", process.env.VERCEL_URL)
+  console.log("VERCEL_ENV: ", process.env.VERCEL_ENV)
+  console.log("VERCEL_BRANCH_URL: ", process.env.VERCEL_BRANCH_URL)
+  console.log("NEXT_PUBLIC_VERCEL_ENV: ", process.env.NEXT_PUBLIC_VERCEL_ENV)
+  console.log("NEXT_PUBLIC_VERCEL_URL: ", process.env.NEXT_PUBLIC_VERCEL_URL)
+  console.log("NEXT_PUBLIC_VERCEL_BRANCH_URL: ", process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL)
+  console.log("NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL: ", process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL)
 
   useEffect(() => {
     const fetchData = async () => {

--- a/src/app/components/issuePage/index.tsx
+++ b/src/app/components/issuePage/index.tsx
@@ -31,6 +31,9 @@ const IssuePage = (props: IssuePageProps) => {
   const { thisIssueData, currentSection, issueSections, previewURL } = props
   const [currentAds, setCurrentAds] = useState<Ads[] | undefined>(undefined)
 
+  const env = process.env.NODE_ENV
+  console.log("env", env)
+
   useEffect(() => {
     const fetchData = async () => {
       if (!currentAds) {

--- a/src/app/components/issuePage/index.tsx
+++ b/src/app/components/issuePage/index.tsx
@@ -33,6 +33,7 @@ const IssuePage = (props: IssuePageProps) => {
 
   const env = process.env.NODE_ENV
   console.log("env", env)
+  console.log("NEXT_PUBLIC_BASE_URL: ", process.env.NEXT_PUBLIC_BASE_URL)
 
   useEffect(() => {
     const fetchData = async () => {

--- a/src/app/components/issuePage/index.tsx
+++ b/src/app/components/issuePage/index.tsx
@@ -31,17 +31,6 @@ const IssuePage = (props: IssuePageProps) => {
   const { thisIssueData, currentSection, issueSections, previewURL } = props
   const [currentAds, setCurrentAds] = useState<Ads[] | undefined>(undefined)
 
-  const env = process.env.NODE_ENV
-  console.log("env", env)
-  console.log("NEXT_PUBLIC_BASE_URL: ", process.env.NEXT_PUBLIC_BASE_URL)
-  console.log("VERCEL_URL: ", process.env.VERCEL_URL)
-  console.log("VERCEL_ENV: ", process.env.VERCEL_ENV)
-  console.log("VERCEL_BRANCH_URL: ", process.env.VERCEL_BRANCH_URL)
-  console.log("NEXT_PUBLIC_VERCEL_ENV: ", process.env.NEXT_PUBLIC_VERCEL_ENV)
-  console.log("NEXT_PUBLIC_VERCEL_URL: ", process.env.NEXT_PUBLIC_VERCEL_URL)
-  console.log("NEXT_PUBLIC_VERCEL_BRANCH_URL: ", process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL)
-  console.log("NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL: ", process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL)
-
   useEffect(() => {
     const fetchData = async () => {
       if (!currentAds) {

--- a/src/app/components/issuePage/layout/issue.tsx
+++ b/src/app/components/issuePage/layout/issue.tsx
@@ -20,6 +20,8 @@ const IssueLayout = (props: IssuePageProps) => {
   const { year, month } = thisIssueData
   const currentArticles = thisIssueData.articles
 
+  console.log("Issue Layout", props)
+
   // Filter the currentArticles to get only the articles with a slideshow image
   const currentSlides: Articles[] = []
   currentArticles.forEach((article: Articles) => {

--- a/src/app/components/issuePage/layout/issue.tsx
+++ b/src/app/components/issuePage/layout/issue.tsx
@@ -28,7 +28,7 @@ const IssueLayout = (props: IssuePageProps) => {
     }
   })
 
-  console.log("VERCEL_ENV", process.env.VERCEL_ENV)
+  console.log("VERCEL_ENV", process.env.NEXT_PUBLIC_VERCEL_ENV)
 
   const promoProps = { currentArticles, year, month }
   const tocProps = { thisIssueData, currentSections, permalink, year, month }

--- a/src/app/components/issuePage/layout/issue.tsx
+++ b/src/app/components/issuePage/layout/issue.tsx
@@ -28,6 +28,8 @@ const IssueLayout = (props: IssuePageProps) => {
     }
   })
 
+  console.log("VERCEL_ENV", process.env.VERCEL_ENV)
+
   const promoProps = { currentArticles, year, month }
   const tocProps = { thisIssueData, currentSections, permalink, year, month }
 

--- a/src/app/components/issuePage/layout/issue.tsx
+++ b/src/app/components/issuePage/layout/issue.tsx
@@ -10,15 +10,15 @@ import TableOfContents from "../tableOfContents"
 import SubscribeAd from "../subscribeAd"
 
 export interface LayoutProps {
-  issueData: Issues
+  thisIssueData: Issues
   currentSection?: Sections
 }
 
 const IssueLayout = (props: IssuePageProps) => {
-  const { issueData, sections, permalink } = props
-  const currentSections = sections
-  const { year, month } = issueData
-  const currentArticles = issueData.articles
+  const { thisIssueData, issueSections, permalink } = props
+  const currentSections = issueSections
+  const { year, month } = thisIssueData
+  const currentArticles = thisIssueData.articles
 
   // Filter the currentArticles to get only the articles with a slideshow image
   const currentSlides: Articles[] = []
@@ -29,7 +29,7 @@ const IssueLayout = (props: IssuePageProps) => {
   })
 
   const promoProps = { currentArticles, year, month }
-  const tocProps = { issueData, currentSections, permalink, year, month }
+  const tocProps = { thisIssueData, currentSections, permalink, year, month }
 
   return (
     <>

--- a/src/app/components/issuePage/layout/issue.tsx
+++ b/src/app/components/issuePage/layout/issue.tsx
@@ -20,8 +20,6 @@ const IssueLayout = (props: IssuePageProps) => {
   const { year, month } = thisIssueData
   const currentArticles = thisIssueData.articles
 
-  console.log("Issue Layout", props)
-
   // Filter the currentArticles to get only the articles with a slideshow image
   const currentSlides: Articles[] = []
   currentArticles.forEach((article: Articles) => {

--- a/src/app/components/issuePage/layout/section.tsx
+++ b/src/app/components/issuePage/layout/section.tsx
@@ -6,23 +6,23 @@ import SubscribeAd from "../subscribeAd"
 import { LayoutProps } from "./issue"
 
 const SectionLayout = (props: LayoutProps) => {
-  const { issueData, currentSection } = props
+  const { thisIssueData, currentSection } = props
 
   if (!currentSection) {
     return <></>
   }
 
-  const { year, month } = issueData
+  const { year, month } = thisIssueData
 
   // get the articles that belong to the current section
-  const currentArticles = issueData.articles.filter((article: Articles) => {
+  const currentArticles = thisIssueData.articles.filter((article: Articles) => {
     return article.section.slug === currentSection.slug
   })
 
   // If the current section is the Critics Page, add the Editors Message to the beginning of the currentArticles array
   if (currentSection.slug === "criticspage") {
     // find the articles that belong to the Editors Message section
-    const editorsMessage = issueData.articles.find((article: Articles) => {
+    const editorsMessage = thisIssueData.articles.find((article: Articles) => {
       return article.section.slug === "editorsmessage"
     })
     // add those articles to the beginning of the currentArticles array

--- a/src/app/components/issuePage/layout/specialIssue.tsx
+++ b/src/app/components/issuePage/layout/specialIssue.tsx
@@ -6,19 +6,19 @@ import { LayoutProps } from "./issue"
 import SubscribeAd from "../subscribeAd"
 
 const SpecialIssue = (props: LayoutProps) => {
-  const { issueData } = props
+  const { thisIssueData } = props
 
-  const currentArticles = issueData.articles
+  const currentArticles = thisIssueData.articles
 
   const allArticles = currentArticles.map((article: Articles, i: number) => {
     const permalink = getPermalink({
-      issueSlug: issueData.slug,
+      issueSlug: thisIssueData.slug,
       section: article.section.slug,
       type: PageType.SpecialIssueArticle,
       slug: article.slug,
     })
     const sectionPermalink = getPermalink({
-      issueSlug: issueData.slug,
+      issueSlug: thisIssueData.slug,
       section: article.section.slug,
       type: PageType.SpecialIssueSection,
       slug: article.section.slug,
@@ -38,11 +38,11 @@ const SpecialIssue = (props: LayoutProps) => {
 
   return (
     <div className="grid-col-8">
-      {(issueData.summary || issueData.credits) && (
+      {(thisIssueData.summary || thisIssueData.credits) && (
         <header className="section">
           <div className="description">
-            {issueData.summary && <div className="blurb">{parse(issueData.summary)}</div>}
-            {issueData.credits && <div className="credits">{parse(issueData.credits)}</div>}
+            {thisIssueData.summary && <div className="blurb">{parse(thisIssueData.summary)}</div>}
+            {thisIssueData.credits && <div className="credits">{parse(thisIssueData.credits)}</div>}
           </div>
         </header>
       )}

--- a/src/app/components/issuePage/layout/specialSection.tsx
+++ b/src/app/components/issuePage/layout/specialSection.tsx
@@ -5,14 +5,14 @@ import SubscribeAd from "../subscribeAd"
 import { LayoutProps } from "./issue"
 
 const SpecialSection = (props: LayoutProps) => {
-  const { issueData, currentSection } = props
+  const { thisIssueData, currentSection } = props
 
   if (!currentSection) {
     return <></>
   }
 
-  const { year, month } = issueData
-  const currentArticles = issueData.articles
+  const { year, month } = thisIssueData
+  const currentArticles = thisIssueData.articles
 
   const allArticles = (
     <section className="collection">

--- a/src/app/components/issuePage/layout/tableOfContentsPage.tsx
+++ b/src/app/components/issuePage/layout/tableOfContentsPage.tsx
@@ -3,11 +3,11 @@ import SubscribeAd from "../subscribeAd"
 import TableOfContents from "../tableOfContents"
 
 const TableOfContentsPage = (props: IssuePageProps) => {
-  const { issueData, sections, permalink } = props
-  const currentSections = sections
+  const { thisIssueData, issueSections, permalink } = props
+  const currentSections = issueSections
 
-  const { year, month } = issueData
-  const tocProps = { issueData, currentSections, permalink, year, month }
+  const { year, month } = thisIssueData
+  const tocProps = { thisIssueData, currentSections, permalink, year, month }
 
   return (
     <div className="grid-col-8">

--- a/src/app/components/issuePage/tableOfContents.tsx
+++ b/src/app/components/issuePage/tableOfContents.tsx
@@ -4,7 +4,7 @@ import { PageType, getPermalink } from "../../../../lib/utils"
 import PromoSlim from "../promo/slim"
 
 interface TableOfContentsProps {
-  issueData: Issues
+  thisIssueData: Issues
   currentSections?: Array<Sections>
   permalink: string
   year: number
@@ -55,11 +55,11 @@ const IssueSection = (props: IssueSectionProps) => {
 }
 
 const TableOfContents = (props: TableOfContentsProps) => {
-  const { issueData, currentSections, permalink, year, month } = props
+  const { thisIssueData, currentSections, permalink, year, month } = props
 
   const loading = <div className="loading">Loading...</div>
 
-  const currentArticles = issueData.articles
+  const currentArticles = thisIssueData.articles
 
   return (
     <div className="collection table-of-contents">

--- a/src/app/components/issueRail/bylines.tsx
+++ b/src/app/components/issueRail/bylines.tsx
@@ -3,19 +3,21 @@ import { ArticlesContributors } from "../../../../lib/types"
 interface BylinesProps {
   contributors: ArticlesContributors[]
   byline_override?: string | null
+  guestCritic?: boolean
 }
 const Bylines = (props: BylinesProps) => {
-  const { contributors, byline_override } = props
+  const { contributors, byline_override, guestCritic } = props
   if (!contributors || contributors.length === 0) {
     return null
   }
+  const by = guestCritic ? <strong>Guest Critic:</strong> : "By"
   return (
     <cite>
       {byline_override ? (
         <span>{byline_override}</span>
       ) : (
         <>
-          <span>By </span>
+          <span>{by} </span>
           {contributors.map((contributor: any, i: number) => {
             const isLast = i === contributors.length - 1
             const isFirst = i === 0

--- a/src/app/components/issueRail/coverImage.tsx
+++ b/src/app/components/issueRail/coverImage.tsx
@@ -4,29 +4,29 @@ import Image from "next/image"
 import { usePopup } from "./popupProvider"
 
 interface CoverImagesProps {
-  issueBasics: Issues
+  thisIssueData: Issues
 }
 
 export const CoverImage = (props: CoverImagesProps) => {
-  const { issueBasics } = props
+  const { thisIssueData } = props
 
   const { setShowPopup, setImages } = usePopup()
   if (
-    !issueBasics.cover_1 ||
-    !issueBasics.cover_1.width ||
-    !issueBasics.cover_1.height ||
-    !issueBasics.cover_1.filename_disk
+    !thisIssueData.cover_1 ||
+    !thisIssueData.cover_1.width ||
+    !thisIssueData.cover_1.height ||
+    !thisIssueData.cover_1.filename_disk
   ) {
     return <div className={`issue-covers loading`}></div>
   }
 
   const covers = [
-    issueBasics.cover_1,
-    issueBasics.cover_2,
-    issueBasics.cover_3,
-    issueBasics.cover_4,
-    issueBasics.cover_5,
-    issueBasics.cover_6,
+    thisIssueData.cover_1,
+    thisIssueData.cover_2,
+    thisIssueData.cover_3,
+    thisIssueData.cover_4,
+    thisIssueData.cover_5,
+    thisIssueData.cover_6,
   ]
 
   const handleClick = async (e: React.MouseEvent<Element, MouseEvent>) => {
@@ -35,9 +35,9 @@ export const CoverImage = (props: CoverImagesProps) => {
     setShowPopup(true)
   }
 
-  const alt = issueBasics.cover_1.caption
-    ? stripHtml(issueBasics.cover_1.caption).result
-    : `${issueBasics.title} — The Brooklyn Rail`
+  const alt = thisIssueData.cover_1.caption
+    ? stripHtml(thisIssueData.cover_1.caption).result
+    : `${thisIssueData.title} — The Brooklyn Rail`
 
   return (
     <div className={`issue-covers`}>
@@ -45,9 +45,9 @@ export const CoverImage = (props: CoverImagesProps) => {
         <Image
           priority
           id={`cover-1`}
-          src={`${process.env.NEXT_PUBLIC_IMAGE_PATH}${issueBasics.cover_1.filename_disk}`}
-          width={issueBasics.cover_1.width}
-          height={issueBasics.cover_1.height}
+          src={`${process.env.NEXT_PUBLIC_IMAGE_PATH}${thisIssueData.cover_1.filename_disk}`}
+          width={thisIssueData.cover_1.width}
+          height={thisIssueData.cover_1.height}
           style={{
             width: "100%",
             height: "auto",

--- a/src/app/components/issueRail/index.tsx
+++ b/src/app/components/issueRail/index.tsx
@@ -165,7 +165,7 @@ const IssueRail = (props: IssueRailProps) => {
         <div className="issue-details">
           <div className="grid-row">
             <div className="grid-col-6">
-              <CoverImage issueBasics={thisIssueData} />
+              <CoverImage thisIssueData={thisIssueData} />
             </div>
             <div className="grid-col-6">
               <div className="issue-links">

--- a/src/app/components/page/index.tsx
+++ b/src/app/components/page/index.tsx
@@ -2,49 +2,13 @@
 import IssueRail from "../issueRail"
 import Footer from "../footer"
 import CoversPopup from "../issueRail/coversPopup"
-import { Issues } from "../../../../lib/types"
-import { getIssueData, getSpecialIssueData } from "../../../../lib/utils"
 import Link from "next/link"
-import { useEffect, useState } from "react"
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import { faMagnifyingGlass } from "@fortawesome/free-solid-svg-icons"
 import { PageProps } from "@/app/[...slug]/page"
 import PageHead from "./pageHead"
 import PageBody from "./pageBody"
 
 const Page = (props: PageProps) => {
-  const { issueBasics } = props
-
-  const [issueData, setIssueData] = useState<Issues | null>(null)
-
-  useEffect(() => {
-    const fetchData = async () => {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/sections?issueId=${issueBasics.id}`, {
-        next: { revalidate: 10 },
-      })
-      const sections = await res.json()
-
-      // TODO: Refactor this to use a single function to fetch issue data from APIs
-      let issueDataPromise
-      if (!issueData) {
-        if (issueBasics.special_issue) {
-          issueDataPromise = !issueData ? getSpecialIssueData({ slug: issueBasics.slug }) : Promise.resolve(issueData)
-        } else {
-          issueDataPromise = !issueData
-            ? getIssueData({ year: issueBasics.year, month: issueBasics.month })
-            : Promise.resolve(issueData)
-        }
-        // Fetch all the data in parallel
-        const [fetchedIssueData] = await Promise.all([sections, issueDataPromise])
-
-        // Update the state with the fetched data as it becomes available
-        setIssueData(fetchedIssueData)
-      }
-    }
-
-    // Call the fetchData function and handle any errors
-    fetchData().catch((error) => console.error("Failed to fetch data on Article page:", error))
-  }, [issueBasics, issueData, setIssueData])
+  const { thisIssueData } = props
 
   return (
     <>
@@ -53,13 +17,13 @@ const Page = (props: PageProps) => {
           <div className="grid-container">
             <div className="grid-row grid-gap-3">
               <div className="grid-col-12 tablet-lg:grid-col-4 desktop-lg:grid-col-3">
-                <IssueRail currentIssueBasics={issueBasics} />
+                <IssueRail thisIssueData={thisIssueData} />
               </div>
 
               <div className="grid-col-12 tablet-lg:grid-col-8 desktop-lg:grid-col-9">
                 <header id="article_header">
                   <Link className="mobile_nav_btn" href="">
-                    <i className="fas fa-angle-double-left"></i> <span>{props.issueBasics.title}</span> Issue
+                    <i className="fas fa-angle-double-left"></i> <span>{props.thisIssueData.title}</span> Issue
                   </Link>
 
                   <nav>

--- a/src/app/components/preview/issue/index.tsx
+++ b/src/app/components/preview/issue/index.tsx
@@ -6,8 +6,8 @@ import IssuePage from "../../issuePage"
 import { PageLayout } from "@/app/page"
 
 const IssuePreview = (props: IssuePreviewProps) => {
-  const { issueData, isEnabled, previewPassword } = props
-  const cookieSlug = `rail_preview_${issueData.slug}`
+  const { thisIssueData, isEnabled, previewPassword } = props
+  const cookieSlug = `rail_preview_${thisIssueData.slug}`
   const [password, setPassword] = useState("")
   const [isViewable, setIsViewable] = useState(false)
   const [passwordError, setPasswordError] = useState<string | undefined>()
@@ -44,7 +44,7 @@ const IssuePreview = (props: IssuePreviewProps) => {
     return <Password {...passwordProps} />
   }
 
-  const previewURL = `${process.env.NEXT_PUBLIC_BASE_URL}/preview/issue/${issueData.year}/${issueData.month}`
+  const previewURL = `${process.env.NEXT_PUBLIC_BASE_URL}/preview/issue/${thisIssueData.year}/${thisIssueData.month}`
   return (
     <>
       <IssuePage {...props} layout={PageLayout.Issue} previewURL={previewURL} />

--- a/src/app/components/promo/standard.tsx
+++ b/src/app/components/promo/standard.tsx
@@ -48,7 +48,6 @@ const PromoStandard = (props: PromoProps) => {
   const { article, showSection, showImage, permalink, order } = props
   const { title, excerpt, promo_banner } = article
 
-  console.log("promo standard", props)
   const orderNum = (
     <span className="sort">
       <span>{order}</span>

--- a/src/app/components/promo/standard.tsx
+++ b/src/app/components/promo/standard.tsx
@@ -47,6 +47,8 @@ const PromoBanner = (props: PromoBannerProps) => {
 const PromoStandard = (props: PromoProps) => {
   const { article, showSection, showImage, permalink, order } = props
   const { title, excerpt, promo_banner } = article
+
+  console.log("promo standard", props)
   const orderNum = (
     <span className="sort">
       <span>{order}</span>

--- a/src/app/contributor/[slug]/page.tsx
+++ b/src/app/contributor/[slug]/page.tsx
@@ -14,7 +14,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 60 seconds.
-export const revalidate = 600
+export const revalidate = process.env.VERCEL_ENV === "production" ? 600 : 0
 
 export async function generateMetadata({ params }: any): Promise<Metadata> {
   const data = await getData({ params })

--- a/src/app/contributor/[slug]/page.tsx
+++ b/src/app/contributor/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import parse from "html-react-parser"
-import { ArticlesContributors, Contributors, Issues } from "../../../../lib/types"
-import { getContributor, getCurrentIssueBasics, getPermalink, PageType } from "../../../../lib/utils"
+import { ArticlesContributors } from "../../../../lib/types"
+import { getContributor, getCurrentIssueData, getPermalink, PageType } from "../../../../lib/utils"
 import PromoSection from "@/app/components/promo/section"
 import { Metadata } from "next"
 import { stripHtml } from "string-strip-html"
@@ -117,7 +117,7 @@ export default async function Contributor({ params }: { params: ContributorsPara
         <div className="grid-container">
           <div className="grid-row grid-gap-3">
             <div className="grid-col-12 tablet-lg:grid-col-4 desktop-lg:grid-col-3">
-              <IssueRail currentIssueBasics={data.currentIssueBasics} />
+              <IssueRail thisIssueData={data.thisIssueData} />
             </div>
 
             <div className="grid-col-12 tablet-lg:grid-col-8 desktop-lg:grid-col-9">
@@ -164,14 +164,14 @@ interface ContributorsParams {
 
 async function getData({ params }: { params: ContributorsParams }) {
   const slug = params.slug
-  const currentIssueBasics = await getCurrentIssueBasics()
+  const thisIssueData = await getCurrentIssueData()
 
   // Get all contributors
   // NOTE: There are multiple contributors with the same slug
   // This returns all contributors with the same slug, but their specific name and bio information may be different
   const allContributors = await getContributor(slug)
 
-  if (!allContributors || allContributors.length == 0 || !currentIssueBasics) {
+  if (!allContributors || allContributors.length == 0 || !thisIssueData) {
     return notFound()
   }
 
@@ -190,13 +190,16 @@ async function getData({ params }: { params: ContributorsParams }) {
   })
 
   return {
-    currentIssueBasics,
+    thisIssueData,
     contributorData,
     articles: allArticles,
     permalink,
   }
 }
 
+function getCurrentIssue() {
+  throw new Error("Function not implemented.")
+}
 // export async function generateStaticParams() {
 //   let allContributors = await getAllContributors()
 //   // filter out contributors with no articles

--- a/src/app/contributor/[slug]/page.tsx
+++ b/src/app/contributor/[slug]/page.tsx
@@ -14,7 +14,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 60 seconds.
-export const revalidate = process.env.VERCEL_ENV === "production" ? 600 : 0
+export const revalidate = process.env.NEXT_PUBLIC_VERCEL_ENV === "production" ? 600 : 0
 
 export async function generateMetadata({ params }: any): Promise<Metadata> {
   const data = await getData({ params })

--- a/src/app/contributors/page.tsx
+++ b/src/app/contributors/page.tsx
@@ -10,7 +10,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 5 mins.
-export const revalidate = 300
+export const revalidate = process.env.VERCEL_ENV === "production" ? 600 : 0
 
 export default async function ContributorsIndex() {
   const data = await getData()

--- a/src/app/contributors/page.tsx
+++ b/src/app/contributors/page.tsx
@@ -10,7 +10,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 5 mins.
-export const revalidate = process.env.VERCEL_ENV === "production" ? 600 : 0
+export const revalidate = process.env.NEXT_PUBLIC_VERCEL_ENV === "production" ? 600 : 0
 
 export default async function ContributorsIndex() {
   const data = await getData()

--- a/src/app/contributors/page.tsx
+++ b/src/app/contributors/page.tsx
@@ -1,5 +1,5 @@
 import { Contributors, Issues } from "../../../lib/types"
-import { getAllContributors, getCurrentIssueBasics, getPermalink, PageType } from "../../../lib/utils"
+import { getAllContributors, getCurrentIssueData, getPermalink, PageType } from "../../../lib/utils"
 import Link from "next/link"
 import IssueRail from "../components/issueRail"
 import { notFound } from "next/navigation"
@@ -40,7 +40,7 @@ export default async function ContributorsIndex() {
         <div className="grid-container">
           <div className="grid-row grid-gap-3">
             <div className="grid-col-12 tablet-lg:grid-col-4 desktop-lg:grid-col-3">
-              <IssueRail currentIssueBasics={data.currentIssueBasics} />
+              <IssueRail thisIssueData={data.thisIssueData} />
             </div>
 
             <div className="grid-col-12 tablet-lg:grid-col-8 desktop-lg:grid-col-9">
@@ -87,14 +87,14 @@ async function getData() {
   }
   // filter out contributors with no articles
   allContributors = allContributors.filter((contributor: Contributors) => contributor.articles.length > 0)
-  const currentIssueBasics = await getCurrentIssueBasics()
+  const thisIssueData = await getCurrentIssueData()
 
-  if (!currentIssueBasics) {
+  if (!thisIssueData) {
     return notFound()
   }
 
   return {
-    currentIssueBasics,
+    thisIssueData,
     allContributors,
   }
 }

--- a/src/app/contributors/sitemap.tsx
+++ b/src/app/contributors/sitemap.tsx
@@ -9,7 +9,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 60 mins.
-export const revalidate = 3600
+export const revalidate = process.env.VERCEL_ENV === "production" ? 3600 : 0
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   let allContributors = await getAllContributors()

--- a/src/app/contributors/sitemap.tsx
+++ b/src/app/contributors/sitemap.tsx
@@ -9,7 +9,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 60 mins.
-export const revalidate = process.env.VERCEL_ENV === "production" ? 3600 : 0
+export const revalidate = process.env.NEXT_PUBLIC_VERCEL_ENV === "production" ? 3600 : 0
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   let allContributors = await getAllContributors()

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,13 +12,6 @@ export const dynamicParams = true
 // request comes in, at most once every 60 seconds.
 export const revalidate = 60
 
-// Set the Viewport to show the full page of the Rail on mobile devices
-export const viewport: Viewport = {
-  width: "device-width",
-  initialScale: 0.405,
-  // interactiveWidget: "resizes-visual",
-}
-
 export enum PageLayout {
   Issue = "issue",
   Section = "section",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 import { Issues, Sections } from "../../lib/types"
 import IssuePage from "@/app/components/issuePage"
-import { getCurrentIssueData, getPermalink, getSectionsByIssueId, PageType } from "../../lib/utils"
+import { getCurrentIssueData, getPermalink, PageType } from "../../lib/utils"
 import { notFound } from "next/navigation"
 
 // Dynamic segments not included in generateStaticParams are generated on demand.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 60 seconds.
-export const revalidate = process.env.VERCEL_ENV === "production" ? 600 : 0
+export const revalidate = process.env.NEXT_PUBLIC_VERCEL_ENV === "production" ? 600 : 0
 
 export enum PageLayout {
   Issue = "issue",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 60 seconds.
-export const revalidate = 600
+export const revalidate = process.env.VERCEL_ENV === "production" ? 600 : 0
 
 export enum PageLayout {
   Issue = "issue",

--- a/src/app/preview/article/[slug]/page.tsx
+++ b/src/app/preview/article/[slug]/page.tsx
@@ -8,7 +8,7 @@ import { notFound } from "next/navigation"
 
 export interface ArticlePreviewProps {
   articleData: Articles
-  issueBasics?: Issues
+  thisIssueData?: Issues
   currentSection?: Sections
   permalink: string
   errorCode?: number
@@ -70,14 +70,14 @@ export default async function ArticlePreviewPage({ params }: { params: PreviewPa
 
   const data = await getData({ params })
 
-  const { articleData, issueBasics, permalink, currentSection, directusUrl, previewPassword } = data
+  const { articleData, thisIssueData, permalink, currentSection, directusUrl, previewPassword } = data
   if (!articleData || !permalink || !previewPassword || !directusUrl) {
     return { props: { errorCode: 400, errorMessage: "This article does not exist" } }
   }
 
   const articlePreviewProps = {
     articleData,
-    issueBasics,
+    thisIssueData,
     permalink,
     currentSection,
     directusUrl,
@@ -103,7 +103,7 @@ async function getData({ params }: { params: PreviewParams }) {
     return notFound()
   }
 
-  const issueBasics = articleData.issue
+  const thisIssueData = articleData.issue
   const currentSection = articleData.section
 
   const permalink = getPermalink({
@@ -117,7 +117,7 @@ async function getData({ params }: { params: PreviewParams }) {
   return {
     articleData,
     currentSection,
-    issueBasics,
+    thisIssueData,
     permalink,
     previewPassword,
     directusUrl,

--- a/src/app/preview/issue/[year]/[month]/page.tsx
+++ b/src/app/preview/issue/[year]/[month]/page.tsx
@@ -1,11 +1,5 @@
 import { stripHtml } from "string-strip-html"
-import {
-  PageType,
-  getPermalink,
-  getPreviewIssue,
-  getPreviewPassword,
-  getSectionsByIssueId,
-} from "../../../../../../lib/utils"
+import { PageType, getPermalink, getPreviewIssue, getPreviewPassword } from "../../../../../../lib/utils"
 import { Issues, Sections } from "../../../../../../lib/types"
 import { Metadata } from "next"
 import { draftMode } from "next/headers"
@@ -14,7 +8,7 @@ import { notFound } from "next/navigation"
 
 export interface IssuePreviewProps {
   thisIssueData: Issues
-  sections: Sections[]
+  issueSections: Sections[]
   permalink: string
   errorCode?: number
   errorMessage?: string
@@ -63,14 +57,14 @@ export default async function IssuePreviewPage({ params }: { params: PreviewPara
 
   const data = await getData({ params })
 
-  const { thisIssueData, sections, permalink, directusUrl, previewPassword } = data
-  if (!thisIssueData || !sections || !permalink || !previewPassword || !directusUrl) {
+  const { thisIssueData, issueSections, permalink, directusUrl, previewPassword } = data
+  if (!thisIssueData || !issueSections || !permalink || !previewPassword || !directusUrl) {
     return { props: { errorCode: 400, errorMessage: "This article does not exist" } }
   }
 
   const issuePreviewProps = {
     thisIssueData,
-    sections,
+    issueSections,
     permalink,
     directusUrl,
     previewPassword,
@@ -95,10 +89,13 @@ async function getData({ params }: { params: PreviewParams }) {
   if (!thisIssueData) {
     return notFound()
   }
-  // Get the current list of Sections used in this Issue (draft or published)
-  const sections = await getSectionsByIssueId(thisIssueData.id, thisIssueData.status)
 
-  if (!sections) {
+  // make an array of all the sections used in thisIssueData.articles and remove any duplicates
+  const issueSections = thisIssueData.articles
+    .map((article) => article.section)
+    .filter((section, index, self) => self.findIndex((s) => s.id === section.id) === index)
+
+  if (!issueSections) {
     return notFound()
   }
 
@@ -113,7 +110,7 @@ async function getData({ params }: { params: PreviewParams }) {
 
   return {
     thisIssueData,
-    sections,
+    issueSections,
     permalink,
     previewPassword,
     directusUrl,

--- a/src/app/preview/issue/[year]/[month]/page.tsx
+++ b/src/app/preview/issue/[year]/[month]/page.tsx
@@ -13,7 +13,7 @@ import IssuePreview from "@/app/components/preview/issue"
 import { notFound } from "next/navigation"
 
 export interface IssuePreviewProps {
-  issueData: Issues
+  thisIssueData: Issues
   sections: Sections[]
   permalink: string
   errorCode?: number
@@ -28,7 +28,7 @@ export interface IssuePreviewProps {
 export async function generateMetadata({ params }: { params: PreviewParams }): Promise<Metadata> {
   const data = await getData({ params })
 
-  const { title } = data.issueData
+  const { title } = data.thisIssueData
   const ogtitle = stripHtml(title).result
   const ogdescription = ""
 
@@ -63,13 +63,13 @@ export default async function IssuePreviewPage({ params }: { params: PreviewPara
 
   const data = await getData({ params })
 
-  const { issueData, sections, permalink, directusUrl, previewPassword } = data
-  if (!issueData || !sections || !permalink || !previewPassword || !directusUrl) {
+  const { thisIssueData, sections, permalink, directusUrl, previewPassword } = data
+  if (!thisIssueData || !sections || !permalink || !previewPassword || !directusUrl) {
     return { props: { errorCode: 400, errorMessage: "This article does not exist" } }
   }
 
   const issuePreviewProps = {
-    issueData,
+    thisIssueData,
     sections,
     permalink,
     directusUrl,
@@ -91,20 +91,20 @@ async function getData({ params }: { params: PreviewParams }) {
   const year = parseInt(params.year, 10)
   const month = parseInt(params.month, 10)
 
-  const issueData = await getPreviewIssue(year, month)
-  if (!issueData) {
+  const thisIssueData = await getPreviewIssue(year, month)
+  if (!thisIssueData) {
     return notFound()
   }
   // Get the current list of Sections used in this Issue (draft or published)
-  const sections = await getSectionsByIssueId(issueData.id, issueData.status)
+  const sections = await getSectionsByIssueId(thisIssueData.id, thisIssueData.status)
 
   if (!sections) {
     return notFound()
   }
 
   const permalink = getPermalink({
-    year: issueData.year,
-    month: issueData.month,
+    year: thisIssueData.year,
+    month: thisIssueData.month,
     type: PageType.Issue,
   })
 
@@ -112,7 +112,7 @@ async function getData({ params }: { params: PreviewParams }) {
   const directusUrl = process.env.NEXT_PUBLIC_DIRECTUS_URL
 
   return {
-    issueData,
+    thisIssueData,
     sections,
     permalink,
     previewPassword,

--- a/src/app/sitemap.tsx
+++ b/src/app/sitemap.tsx
@@ -8,7 +8,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 60 mins.
-export const revalidate = process.env.VERCEL_ENV === "production" ? 3600 : 0
+export const revalidate = process.env.NEXT_PUBLIC_VERCEL_ENV === "production" ? 3600 : 0
 
 interface SiteLinksProps {
   url: string

--- a/src/app/sitemap.tsx
+++ b/src/app/sitemap.tsx
@@ -8,7 +8,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 60 mins.
-export const revalidate = 3600
+export const revalidate = process.env.VERCEL_ENV === "production" ? 3600 : 0
 
 interface SiteLinksProps {
   url: string

--- a/src/app/special/[issueSlug]/[section]/[slug]/page.tsx
+++ b/src/app/special/[issueSlug]/[section]/[slug]/page.tsx
@@ -10,7 +10,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 60 mins.
-export const revalidate = process.env.VERCEL_ENV === "production" ? 3600 : 0
+export const revalidate = process.env.NEXT_PUBLIC_VERCEL_ENV === "production" ? 3600 : 0
 
 export async function generateMetadata({ params }: { params: SpecialArticleParams }): Promise<Metadata> {
   const data = await getData({ params })

--- a/src/app/special/[issueSlug]/[section]/[slug]/page.tsx
+++ b/src/app/special/[issueSlug]/[section]/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import { stripHtml } from "string-strip-html"
-import { PageType, getArticle, getOGImage, getPermalink, getSpecialIssueBasics } from "../../../../../../lib/utils"
+import { PageType, getArticle, getOGImage, getPermalink, getSpecialIssueData } from "../../../../../../lib/utils"
 import { Metadata } from "next"
 import Article from "@/app/components/article"
 import { notFound } from "next/navigation"
@@ -65,20 +65,20 @@ interface SpecialArticleParams {
 async function getData({ params }: { params: SpecialArticleParams }) {
   const slug = String(params.slug)
   const issueSlug = String(params.issueSlug)
-  // const section = String(params.section)
 
-  const issueBasics = await getSpecialIssueBasics({ slug: issueSlug }) // A limited set of data for the issue
+  const thisIssueData = await getSpecialIssueData({ slug: issueSlug }) // A limited set of data for the issue
   const articleData = await getArticle(slug, "published")
-  if (!articleData || !issueBasics) {
+
+  if (!articleData || !thisIssueData) {
     return notFound()
   }
 
   const currentSection = articleData.section
 
   const permalink = getPermalink({
-    year: issueBasics.year,
-    month: issueBasics.month,
-    issueSlug: issueBasics.slug,
+    year: thisIssueData.year,
+    month: thisIssueData.month,
+    issueSlug: thisIssueData.slug,
     section: currentSection.slug,
     slug: articleData.slug,
     type: PageType.SpecialIssueArticle,
@@ -87,27 +87,9 @@ async function getData({ params }: { params: SpecialArticleParams }) {
   return {
     props: {
       articleData,
-      issueBasics,
+      thisIssueData,
       currentSection,
       permalink,
     },
   }
 }
-
-// export async function generateStaticParams() {
-//   const specialArticlePages = await getSpecialArticlePages()
-
-//   return specialArticlePages.map((article: Articles) => {
-//     // NOTE: This is returning articles with no issues.
-//     // These are the articles that are part of the "Special Issues"
-//     // This might be a BUG, or might be how the REST API is set up.
-//     if (!article.issue) {
-//       return
-//     }
-//     return {
-//       issueSlug: article.issue.slug,
-//       section: article.section.slug,
-//       slug: article.slug,
-//     }
-//   })
-// }

--- a/src/app/special/[issueSlug]/[section]/[slug]/page.tsx
+++ b/src/app/special/[issueSlug]/[section]/[slug]/page.tsx
@@ -10,7 +10,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 60 mins.
-export const revalidate = 3600
+export const revalidate = process.env.VERCEL_ENV === "production" ? 3600 : 0
 
 export async function generateMetadata({ params }: { params: SpecialArticleParams }): Promise<Metadata> {
   const data = await getData({ params })

--- a/src/app/special/[issueSlug]/[section]/page.tsx
+++ b/src/app/special/[issueSlug]/[section]/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata, Viewport } from "next"
 import { PageLayout } from "@/app/page"
-import { PageType, getOGImage, getPermalink, getSectionsByIssueId, getSpecialIssueData } from "../../../../../lib/utils"
+import { PageType, getOGImage, getPermalink, getSpecialIssueData } from "../../../../../lib/utils"
 import { stripHtml } from "string-strip-html"
 import { Sections } from "../../../../../lib/types"
 import IssuePage from "@/app/components/issuePage"

--- a/src/app/special/[issueSlug]/[section]/page.tsx
+++ b/src/app/special/[issueSlug]/[section]/page.tsx
@@ -12,7 +12,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 60 mins.
-export const revalidate = 3600
+export const revalidate = process.env.VERCEL_ENV === "production" ? 3600 : 0
 
 // Set the Viewport to show the full page of the Rail on mobile devices
 export const viewport: Viewport = {

--- a/src/app/special/[issueSlug]/[section]/page.tsx
+++ b/src/app/special/[issueSlug]/[section]/page.tsx
@@ -12,7 +12,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 60 mins.
-export const revalidate = process.env.VERCEL_ENV === "production" ? 3600 : 0
+export const revalidate = process.env.NEXT_PUBLIC_VERCEL_ENV === "production" ? 3600 : 0
 
 // Set the Viewport to show the full page of the Rail on mobile devices
 export const viewport: Viewport = {

--- a/src/app/special/[issueSlug]/[section]/page.tsx
+++ b/src/app/special/[issueSlug]/[section]/page.tsx
@@ -28,7 +28,7 @@ export async function generateMetadata({ params }: { params: SpecialSectionParam
   }
 
   const { name } = data.props.currentSection
-  const { title, cover_1, issue_number } = data.props.issueData
+  const { title, cover_1, issue_number } = data.props.thisIssueData
   const ogtitle = `${name} – ${stripHtml(title).result}`
   const ogdescription = `The ${name} section of issue #${issue_number} of The Brooklyn Rail`
   const ogimageprops = { ogimage: cover_1, title }
@@ -69,39 +69,35 @@ async function getData({ params }: { params: SpecialSectionParams }) {
   const issueSlug: string = params.issueSlug.toString()
   const section = params.section.toString()
 
-  const issueData = await getSpecialIssueData({
+  const thisIssueData = await getSpecialIssueData({
     slug: issueSlug,
   })
 
-  if (!issueData) {
+  if (!thisIssueData) {
     return notFound()
   }
 
-  // Get only the sections that are used in the articles in the current issue
-  const currentSections = await getSectionsByIssueId(issueData.id, issueData.status)
-  if (!currentSections) {
-    return notFound()
-  }
+  // make an array of all the sections used in thisIssueData.articles and remove any duplicates
+  const issueSections = thisIssueData.articles
+    .map((article) => article.section)
+    .filter((section, index, self) => self.findIndex((s) => s.id === section.id) === index)
 
-  if (!currentSections) {
-    return { props: { errorCode: 404, errorMessage: "No currentSections found" } }
-  }
-  const currentSection = currentSections.find((s: Sections) => s.slug === section)
+  const currentSection = issueSections.find((s: Sections) => s.slug === section)
   // If `section` does not exist, set errorCode to a string
   if (!currentSection) {
     return { props: { errorCode: 404, errorMessage: "This section does not exist" } }
   }
 
   const permalink = getPermalink({
-    issueSlug: issueData.slug,
+    issueSlug: thisIssueData.slug,
     section: currentSection.slug,
     type: PageType.SpecialIssueSection,
   })
 
   return {
     props: {
-      issueData,
-      sections: currentSections,
+      thisIssueData,
+      issueSections,
       currentSection,
       permalink,
     },

--- a/src/app/special/[issueSlug]/page.tsx
+++ b/src/app/special/[issueSlug]/page.tsx
@@ -11,7 +11,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 60 mins.
-export const revalidate = process.env.VERCEL_ENV === "production" ? 3600 : 0
+export const revalidate = process.env.NEXT_PUBLIC_VERCEL_ENV === "production" ? 3600 : 0
 
 // Set the Viewport to show the full page of the Rail on mobile devices
 export const viewport: Viewport = {

--- a/src/app/special/[issueSlug]/page.tsx
+++ b/src/app/special/[issueSlug]/page.tsx
@@ -1,6 +1,6 @@
 import IssuePage from "@/app/components/issuePage"
 import { PageLayout } from "@/app/page"
-import { PageType, getOGImage, getPermalink, getSectionsByIssueId, getSpecialIssueData } from "../../../../lib/utils"
+import { PageType, getOGImage, getPermalink, getSpecialIssueData } from "../../../../lib/utils"
 import { stripHtml } from "string-strip-html"
 import { Metadata, Viewport } from "next"
 import { notFound } from "next/navigation"

--- a/src/app/special/[issueSlug]/page.tsx
+++ b/src/app/special/[issueSlug]/page.tsx
@@ -11,7 +11,7 @@ export const dynamicParams = true
 
 // Next.js will invalidate the cache when a
 // request comes in, at most once every 60 mins.
-export const revalidate = 3600
+export const revalidate = process.env.VERCEL_ENV === "production" ? 3600 : 0
 
 // Set the Viewport to show the full page of the Rail on mobile devices
 export const viewport: Viewport = {


### PR DESCRIPTION

## What is changing
Each page now loads the Issue Data for either the Current Issue or the Issue that the article is assigned to.
Previously, we were getting issue data on the client side, after the page loads.

This change will 
- greatly speed up the build times
- reduce the number of queries we are making to the database on each page load
- make it possible to cache nearly all the data loaded on pages
- reduce the monthly cost in Vercel